### PR TITLE
Support formatting options on the command-line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,17 @@ Example:
 
     $ ytool -f some.yaml -s some.string.key value -d float_key 9.9  -i int.key.path 10
 
+
+The output format can be specified to match an existing file:
+
+
+.. code-block:: bash
+
+    $ ytool -f some.yaml -s some.string.key value \
+        --format-width 150 \
+        --format-ident "{mapping: 2, sequence: 4, offset: 2}"
+
+
 ^^^^^^^^^^^^^^^^^^^^^^^^
 Help:
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -31,8 +42,8 @@ Help:
 .. code-block:: bash
 
     $ usage: ytool [-h] --file FILE [--set-string path value] [--set-int path value]
-             [--set-float path value] [--output OUTPUT] [--edit-file]
-             [--verbose]
+             [--set-float path value] [--output OUTPUT] [--edit-file] [--verbose]
+             [--format-explicit-start] [--format-width WIDTH] [--format-indent INDENT]
 
     Set values in yaml file preserving format and comments.
 
@@ -49,6 +60,12 @@ Help:
                             Name of output file
       --edit-file, -e       Edit input file directly
       --verbose, -v         Print debug information to stdout
+      --format-explicit-start, -x
+                            Set explicit start
+      --format-width WIDTH, -w WIDTH
+                            Set max width for output
+      --format-indent INDENT, -m INDENT
+                            Set indent format, eg. "{mapping: 2, sequence: 4, offset: 2}"
 
 
 ---------------

--- a/bin/ytool
+++ b/bin/ytool
@@ -4,7 +4,9 @@ import sys
 import argparse
 
 from ytool import YTool
+from ruamel.yaml import YAML
 
+yaml = YAML(typ='safe')
 parser = argparse.ArgumentParser(description='Set values in yaml file preserving format and comments.')
 parser.add_argument("--file", "-f", action="store",
     help="Name of the chart file to change", required=True)
@@ -22,6 +24,12 @@ parser.add_argument("--edit-file", "-e", action="store_true", default=False,
     help="Edit input file directly")
 parser.add_argument("--verbose", "-v", action="store_true", default=False,
     help="Print debug information to stdout")
+parser.add_argument("--format-explicit-start", "-x", action="store_true", default=False,
+    help="Set explicit start")
+parser.add_argument("--format-width", "-w", type=int, default=None, metavar="WIDTH",
+    help="Set max width for output")
+parser.add_argument("--format-indent", "-m", type=yaml.load, default=None, metavar="INDENT",
+    help="Set indent format, eg. \"{mapping: 2, sequence: 4, offset: 2}\"")
 args = parser.parse_args()
 
 if args.verbose:
@@ -29,6 +37,12 @@ if args.verbose:
 
 ytool = YTool()
 ytool.preserve_quotes = True
+if args.format_indent:
+    ytool.indent(**args.format_indent)
+if args.format_explicit_start:
+    ytool.explicit_start = True
+if args.format_width:
+    ytool.width = args.format_width
 
 with open(args.file) as file:
     data = ytool.load(file)


### PR DESCRIPTION
We have YAML files that have been formatted with specific ruamel.yaml options, so I want to be able to pass those in so ytool dumps the output in the same format as our existing files.

Sample usage:

```
ytool \
  --file /path/to/file.yaml \
  --set-string foo.bar '@default' \
  --format-explicit-start \
  --format-indent "{mapping: 2, sequence: 4, offset: 2}" \
  --format-width 150 \
  --edit-file
```